### PR TITLE
Add support for Laravel v9.0+'s TestCase::$latestResponse

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,8 +84,9 @@ class HtmlTest extends TestCase
 {
     public function test_login_has_header()
     {
-        $response = $this->get('/login');
-        $this->withHtml($response)->assertElementContains('h1#title', 'Login to my app!');
+        $this->get('/login');
+        $this->withHtml()
+            ->assertElementContains('h1#title', 'Login to my app!');
     }
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -84,9 +84,8 @@ class HtmlTest extends TestCase
 {
     public function test_login_has_header()
     {
-        $this->get('/login');
-        $this->withHtml()
-            ->assertElementContains('h1#title', 'Login to my app!');
+        $response = $this->get('/login');
+        $this->withHtml($response)->assertElementContains('h1#title', 'Login to my app!');
     }
 }
 ```

--- a/src/TestsHtml.php
+++ b/src/TestsHtml.php
@@ -4,12 +4,17 @@ namespace Ssddanbrown\AssertHtml;
 
 /**
  * Trait for usage in Laravel testing.
- * Simply pass a test response returned from a get/post/put etc... function.
+ * Optionally pass a test response returned from a get/post/put etc... function.
  */
 trait TestsHtml
 {
-    public function withHtml(\Illuminate\Testing\TestResponse $response): HtmlTest
+    /**
+     * @param TestResponse|null $response if null, will use the most recent response
+     * @return HtmlTest
+     * @link https://github.com/ssddanbrown/asserthtml
+     */
+    public function withHtml(TestResponseIlluminate\Testing\TestResponse $response = null): HtmlTest
     {
-        return new HtmlTest($response->getContent());
+        return new HtmlTest(($response ?? static::$latestResponse)->getContent());
     }
 }


### PR DESCRIPTION
The code style of my workplace's tests avoids nesting and setting a `$response` variable. While writing tests (and our own helper methods), I discovered that Laravel's TestCase has a `static::$latestResponse` that is "the latest test response (if any)" ([source](https://laravel.com/api/10.x/Illuminate/Foundation/Testing/TestCase.html#property_latestResponse)).

I applied a small patch to your code to add support for this functionality. You mentioned in the readme to only submit small changes. I think this counts as a small change.

Here's a quick comparison of the usage between the two versions of `trait TestsHtml`:

```php
// before
public function test_login_has_header()
{
    $response = $this->get('/login');
    $this->withHtml($response)->assertElementContains('h1#title', 'Login to my app!');
}

// after
public function test_login_has_header()
{
    $this->get('/login');
    $this->withHtml()->assertElementContains('h1#title', 'Login to my app!');
}
```